### PR TITLE
Assign `attributes` and `tags` from `variables.tf` to internal `label` module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,11 @@
 module "label" {
-  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.2.0"
-  namespace = "${var.namespace}"
-  name      = "${var.name}"
-  stage     = "${var.stage}"
+  source     = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.2.0"
+  namespace  = "${var.namespace}"
+  name       = "${var.name}"
+  stage      = "${var.stage}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
 }
 
 resource "aws_db_instance" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,18 @@ variable "backup_window" {
   description = "When AWS can perform DB snapshots, can't overlap with maintenance window"
   default     = "22:00-03:00"
 }
+
+variable "delimiter" {
+  type    = "string"
+  default = "-"
+}
+
+variable "attributes" {
+  type    = "list"
+  default = []
+}
+
+variable "tags" {
+  type    = "map"
+  default = {}
+}


### PR DESCRIPTION
## What

* Assign `attributes` and `tags` from `variables.tf` to internal `label` module


## Why

* The internal `label` module's `attributes` and `tags` should be visible from outside of the top-level module
* If `attributes` and `tags` are not accessible from outside, sometimes it's impossible to create more than one AWS resource from the top-level module
* Without additional `attributes`, it's not possible at all to create `aws_security_group` inside the module since many security groups with the same name `${module.label.id}` are created in the same solution
